### PR TITLE
chore: update deps for node 12 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "8"
+  - "10"
+  - "node"

--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
     "url": "https://github.com/akfish/gulp-heap.git"
   },
   "dependencies": {
-    "gulp": "^3.8.11",
-    "gulp-plumber": "^1.0.1",
-    "gulp-rename": "^1.2.2",
-    "gulp-sourcemaps": "^1.5.2",
-    "gulp-util": "^3.0.4",
-    "minimist": "^1.1.1",
-    "underscore": "^1.8.3"
+    "gulp": "^4.0.2",
+    "gulp-plumber": "^1.2.1",
+    "gulp-rename": "^1.4.0",
+    "gulp-sourcemaps": "^2.6.5",
+    "gulp-util": "^3.0.8",
+    "minimist": "^1.2.0",
+    "underscore": "^1.9.1"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
-    "coffee-script": "^1.9.3",
-    "gulp-mocha": "^2.1.2"
+    "chai": "^4.2.0",
+    "coffeescript": "^2.4.1",
+    "gulp-mocha": "^6.0.0"
   }
 }


### PR DESCRIPTION
the outdated deps is currently causing issue at [hexo-inject](https://github.com/hexojs/hexo-inject).